### PR TITLE
Fixed to return the correct pid for the selected container

### DIFF
--- a/AttachToDockerContainer.csproj
+++ b/AttachToDockerContainer.csproj
@@ -53,6 +53,7 @@
     <Compile Include="AttachToDockerContainerDialog.xaml.cs">
       <DependentUpon>AttachToDockerContainerDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Utils\IDEUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="source.extension.vsixmanifest">

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,7 @@
-﻿0.2
+﻿0.2.2
+Updated to obtain the process ID using the project name of the container
+
+0.2
 Add Process ID selection
 
 0.1

--- a/Utils/IDEUtils.cs
+++ b/Utils/IDEUtils.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using EnvDTE;
+using EnvDTE80;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace AttachToDockerContainer.Utils
+{
+    public static class IDEUtils
+    {
+        private static readonly string vsProjectKindSolutionFolder = "{66A26720-8FB5-11D2-AA7E-00C04F688DDE}";
+
+        public static DTE2 GetActiveIDE()
+        {
+            DTE2 dte2 = Package.GetGlobalService(typeof(DTE)) as DTE2;
+            return dte2;
+        }
+
+        private static IEnumerable<Project> GetSolutionFolderProjects(Project solutionFolder)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            List<Project> list = new List<Project>();
+            for (var i = 1; i <= solutionFolder.ProjectItems.Count; i++)
+            {
+                var subProject = solutionFolder.ProjectItems.Item(i).SubProject;
+                if (subProject == null)
+                {
+                    continue;
+                }
+
+                if (subProject.Kind == vsProjectKindSolutionFolder)
+                {
+                    list.AddRange(GetSolutionFolderProjects(subProject));
+                }
+                else
+                {
+                    list.Add(subProject);
+                }
+            }
+            return list;
+        }
+
+        public static IList<Project> GetProjects()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            Projects projects = GetActiveIDE().Solution.Projects;
+            List<Project> list = new List<Project>();
+            var item = projects.GetEnumerator();
+            while (item.MoveNext())
+            {
+                var project = item.Current as Project;
+                if (project == null)
+                {
+                    continue;
+                }
+
+                if (project.Kind == vsProjectKindSolutionFolder)
+                {
+                    list.AddRange(GetSolutionFolderProjects(project));
+                }
+                else
+                {
+                    list.Add(project);
+                }
+            }
+
+            return list;
+        }
+
+        public static IEnumerable<string> GetNameOfProjects()
+        {
+            return GetProjects().Select(p =>
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+                return p.Name;
+            });
+        }
+
+        public static Project GetSelectedProject()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            IVsMonitorSelection monitorSelection =
+                (IVsMonitorSelection) Package.GetGlobalService(
+                    typeof(SVsShellMonitorSelection));
+
+            monitorSelection.GetCurrentSelection(out IntPtr hierarchyPointer,
+                out uint projectItemId,
+                out IVsMultiItemSelect multiItemSelect,
+                out IntPtr selectionContainerPointer);
+
+            IVsHierarchy selectedHierarchy = Marshal.GetTypedObjectForIUnknown(hierarchyPointer, typeof(IVsHierarchy)) as IVsHierarchy;
+
+            object selectedObject = null;
+
+            if (selectedHierarchy != null)
+            {
+                ErrorHandler.ThrowOnFailure(selectedHierarchy.GetProperty(projectItemId, (int) __VSHPROPID.VSHPROPID_ExtObject, out selectedObject));
+            }
+
+            Project selectedProject = selectedObject as Project;
+
+            return selectedProject;
+        }
+    }
+}

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="AttachToDockerContainer.0a9825b5-d65c-457b-bdbe-dfccc1d17c4f" Version="0.1.1" Language="en-US" Publisher="Dreamescaper" />
+        <Identity Id="AttachToDockerContainer.0a9825b5-d65c-457b-bdbe-dfccc1d17c4f" Version="0.2.2" Language="en-US" Publisher="Dreamescaper" />
         <DisplayName>Attach To Docker Container</DisplayName>
         <Description xml:space="preserve">Extension to attach debugger to local docker container via vsdbg</Description>
         <MoreInfo>https://github.com/Dreamescaper/AttachToDockerContainer/</MoreInfo>


### PR DESCRIPTION
Hi @Dreamescaper,

I fixed the issue **#1 exec -it {containerName} pidof dotnet is returning multiples PIDs**

This is the right cli command to get the process id: 

> docker exec -it CONTAINER_NAME pidof DOT_NET_PROJECT_NAME

One suggestion, we can improve the quality of the project adding some tests.

Best regards,

Rolf Rodrigo Krueger